### PR TITLE
fix: remove env variable secrets from vercel.json

### DIFF
--- a/nextjs-app/vercel.json
+++ b/nextjs-app/vercel.json
@@ -2,10 +2,5 @@
   "buildCommand": "npm run build",
   "outputDirectory": ".next",
   "framework": "nextjs",
-  "installCommand": "npm install",
-  "env": {
-    "NEXT_PUBLIC_SUPABASE_URL": "@next_public_supabase_url",
-    "NEXT_PUBLIC_SUPABASE_ANON_KEY": "@next_public_supabase_anon_key",
-    "OPENAI_API_KEY": "@openai_api_key"
-  }
+  "installCommand": "npm install"
 }


### PR DESCRIPTION
Environment variables should be set manually in Vercel dashboard instead of using secrets reference.

🤖 Generated with [Claude Code](https://claude.ai/code)